### PR TITLE
Allow use of $save on resource objects by removing modified 'links' property.

### DIFF
--- a/src/angular-hateoas.js
+++ b/src/angular-hateoas.js
@@ -160,6 +160,15 @@ angular.module("hateoas", ["ngResource"])
 
 						return response || $q.when(response);
 
+					},
+					request: function (config) {
+
+						if (config.data && config.data[linksKey]) {
+							config.data = angular.copy(config.data);
+							delete config.data[linksKey];
+						}
+
+						return config;
 					}
 				};
 			}]


### PR DESCRIPTION
The links property is modified when retrieved to be an object rather than an array.  This pull request deletes the links from any follow on requests preventing serialisation issues server-side with this data type change.

Not sure this is all you'd want to do, but it's working for me like this.
