### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
     "requirejs": "^2.1.11"
   },
   "dependencies": {},
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/jmarquis/angular-hateoas/blog/master/LICENSE"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)
